### PR TITLE
Using django inbuilt now() function on timezone to support v1.4

### DIFF
--- a/async/management/commands/flush_queue.py
+++ b/async/management/commands/flush_queue.py
@@ -3,6 +3,7 @@
 """
 from datetime import datetime
 from django.core.management.base import BaseCommand
+from django.utils import timezone
 from optparse import make_option
 
 from async.models import Job
@@ -23,7 +24,7 @@ class Command(BaseCommand):
         """Command implementation.
         """
         jobs = Job.objects.filter(executed=None).exclude(
-            scheduled__gt=datetime.now())
+            scheduled__gt=timezone.now())
         for job in jobs.iterator():
             print "%s:" % job.pk, job
             job.execute()

--- a/async/models.py
+++ b/async/models.py
@@ -3,6 +3,7 @@
 """
 from datetime import datetime, timedelta
 from django.db import models, transaction
+from django.utils import timezone
 from simplejson import dumps, loads
 from traceback import format_exc
 
@@ -45,7 +46,7 @@ class Job(models.Model):
             _logger.debug(u"%s resolved to %s" % (self.name, function))
             result = transaction.commit_on_success(function)(*args, **kwargs)
         except Exception, exception:
-            self.scheduled = (datetime.now() +
+            self.scheduled = (timezone.now() +
                 timedelta(seconds=4 ** (1 + self.errors.count())))
             def record():
                 """Local function allows us to wrap these updates into a
@@ -57,7 +58,7 @@ class Job(models.Model):
             transaction.commit_on_success(record)()
             raise
         else:
-            self.executed = datetime.now()
+            self.executed = timezone.now()
             self.result = dumps(result)
             self.save() # Single SQL statement so no need for transaction
             return result


### PR DESCRIPTION
Removes warnings when using flush_queue about not taking in account of timezone support is active.

Using django.utils.timezone is fully backwards compatible if a project doesn't have USE_TZ enabled.
