### PR TITLE
Use a filelock to prevent running flush_queue concurrently

### DIFF
--- a/async/management/commands/flush_queue.py
+++ b/async/management/commands/flush_queue.py
@@ -4,6 +4,7 @@
 from datetime import datetime
 from django.core.management.base import BaseCommand
 from optparse import make_option
+from lockfile import FileLock, AlreadyLocked
 
 from async.models import Job
 
@@ -25,30 +26,41 @@ class Command(BaseCommand):
         This implementation is pretty ugly, but does behave in the
         right way.
         """
-        while True:
-            now = datetime.now()
-            by_priority = (Job.objects
-                .filter(executed=None)
-                .exclude(scheduled__gt=now)
-                .order_by('-priority'))
-            number = by_priority.count()
-            if number == 0:
-                print "No jobs found for execution"
-                return
-            def run(jobs):
-                """Run the jobs handed to it
-                """
-                for job in jobs.iterator():
-                    print "%s: %s" % (job.id, unicode(job))
-                    job.execute()
-                    return False
-                return True
-            priority = by_priority[0].priority
-            if run(Job.objects
-                    .filter(executed=None, scheduled__lte=now,
-                        priority=priority)
-                    .order_by('scheduled', 'id')):
-                run(Job.objects
-                    .filter(executed=None, scheduled=None, priority=priority)
-                    .order_by('id'))
+
+        lock = FileLock('async_flush_queue')
+        try:
+            lock.acquire(timeout = -1)
+        except AlreadyLocked:
+            print 'Lock is already set, aborting.'
+            return
+
+        try:
+            while True:
+                now = datetime.now()
+                by_priority = (Job.objects
+                    .filter(executed=None)
+                    .exclude(scheduled__gt=now)
+                    .order_by('-priority'))
+                number = by_priority.count()
+                if number == 0:
+                    print "No jobs found for execution"
+                    return
+                def run(jobs):
+                    """Run the jobs handed to it
+                    """
+                    for job in jobs.iterator():
+                        print "%s: %s" % (job.id, unicode(job))
+                        job.execute()
+                        return False
+                    return True
+                priority = by_priority[0].priority
+                if run(Job.objects
+                        .filter(executed=None, scheduled__lte=now,
+                            priority=priority)
+                        .order_by('scheduled', 'id')):
+                    run(Job.objects
+                        .filter(executed=None, scheduled=None, priority=priority)
+                        .order_by('id'))
+        finally:
+            lock.release()
 


### PR DESCRIPTION
We're using django-async for a medium-sized Django application.  We have a cron job running flush_queue once per minute.  If it ever takes more than a minute to run though, the runs start overlapping, and jobs get executed multiple times.
